### PR TITLE
renovate: Switch to the config:best-practices preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     "customManagers:githubActionsVersions"
   ],
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
# Summary

This updates the Renovate configuration to use the `config:best-practices` preset instead of `config:recommended` in order to enable pinning digests for GitHub Actions versions.