### PR TITLE
Migrate to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "gameboy"
 version = "0.3.0"
-authors = ["Rim <rim.buei@gmail.com>"]
-edition = "2018"
+authors = ["rim-buei <rim.buei@gmail.com>"]
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/gb/cpu/instruction.rs
+++ b/src/gb/cpu/instruction.rs
@@ -1,5 +1,5 @@
 use super::super::bus::Bus;
-use super::oprand::{Address, Condition, Immediate16, Immediate8, Register16 as R16, Register8 as R8};
+use super::oprand::{Address, Condition, Immediate8, Immediate16, Register8 as R8, Register16 as R16};
 use super::processor::Processor;
 use super::state::State;
 

--- a/src/gb/cpu/oprand.rs
+++ b/src/gb/cpu/oprand.rs
@@ -1,5 +1,5 @@
 use super::super::bus::Bus;
-use super::io::{Reader16, Reader8, Writer16, Writer8};
+use super::io::{Reader8, Reader16, Writer8, Writer16};
 use super::state::{Flag, State};
 
 #[derive(Debug, Copy, Clone)]

--- a/src/gb/cpu/processor.rs
+++ b/src/gb/cpu/processor.rs
@@ -1,7 +1,7 @@
 use super::super::bus::Bus;
 use super::super::interrupt;
-use super::io::{Reader16, Reader8, Writer16, Writer8};
-use super::oprand::{Condition, Data16, Immediate8, Register16 as R16, Register8 as R8};
+use super::io::{Reader8, Reader16, Writer8, Writer16};
+use super::oprand::{Condition, Data16, Immediate8, Register8 as R8, Register16 as R16};
 use super::state::{Flag, State};
 
 pub struct Processor<'a, B: Bus + 'a> {

--- a/src/gb/ppu/register.rs
+++ b/src/gb/ppu/register.rs
@@ -68,27 +68,15 @@ impl LCDControl {
     }
 
     pub fn obj_height(&self) -> u8 {
-        if self.0 & (1 << 2) == 0 {
-            8
-        } else {
-            16
-        }
+        if self.0 & (1 << 2) == 0 { 8 } else { 16 }
     }
 
     pub fn bg_map_loc(&self) -> u16 {
-        if self.0 & (1 << 3) == 0 {
-            0x9800
-        } else {
-            0x9C00
-        }
+        if self.0 & (1 << 3) == 0 { 0x9800 } else { 0x9C00 }
     }
 
     pub fn bgwin_tile_loc(&self) -> u16 {
-        if self.0 & (1 << 4) == 0 {
-            0x8800
-        } else {
-            0x8000
-        }
+        if self.0 & (1 << 4) == 0 { 0x8800 } else { 0x8000 }
     }
 
     pub fn win_enabled(&self) -> bool {
@@ -96,11 +84,7 @@ impl LCDControl {
     }
 
     pub fn win_map_loc(&self) -> u16 {
-        if self.0 & (1 << 6) == 0 {
-            0x9800
-        } else {
-            0x9C00
-        }
+        if self.0 & (1 << 6) == 0 { 0x9800 } else { 0x9C00 }
     }
 
     pub fn lcd_enabled(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 mod gb;
 
+use self::gb::GameBoy;
 use self::gb::cartridge::Cartridge;
 use self::gb::joypad::Button;
 use self::gb::screen::{SCREEN_H, SCREEN_W};
-use self::gb::GameBoy;
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::closure::Closure;


### PR DESCRIPTION
# Summary

This migrates the Rust edition from 2018 to 2024. After performing the migration, `cargo fmt` started suggesting some cosmetic changes, so those changes are also applied here.

Closes #28