### PR TITLE
Add GitHub Actions workflow to build static site on push to main branch

### DIFF
--- a/.github/actions/cargo-clippy/action.yml
+++ b/.github/actions/cargo-clippy/action.yml
@@ -1,0 +1,11 @@
+name: cargo clippy
+description: Run cargo clippy
+runs:
+  steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      with:
+        toolchain: nightly
+        components: clippy
+    - name: Run clippy check
+      run: cargo clippy --all-targets --all-features

--- a/.github/actions/cargo-clippy/action.yml
+++ b/.github/actions/cargo-clippy/action.yml
@@ -1,6 +1,7 @@
 name: cargo clippy
 description: Run cargo clippy
 runs:
+  using: composite
   steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -9,3 +10,4 @@ runs:
         components: clippy
     - name: Run clippy check
       run: cargo clippy --all-targets --all-features
+      shell: bash

--- a/.github/actions/cargo-fmt/action.yml
+++ b/.github/actions/cargo-fmt/action.yml
@@ -1,0 +1,11 @@
+name: cargo fmt
+description: Run cargo fmt
+runs:
+  steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      with:
+        toolchain: nightly
+        components: rustfmt
+    - name: Run fmt check
+      run: cargo fmt --all -- --check

--- a/.github/actions/cargo-fmt/action.yml
+++ b/.github/actions/cargo-fmt/action.yml
@@ -1,6 +1,7 @@
 name: cargo fmt
 description: Run cargo fmt
 runs:
+  using: composite
   steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -9,3 +10,4 @@ runs:
         components: rustfmt
     - name: Run fmt check
       run: cargo fmt --all -- --check
+      shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,10 +1,11 @@
-name: CI for pull requests
+name: PR pipeline
 
 permissions: {}
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 env:
   RUSTFLAGS: -Dwarnings
@@ -14,23 +15,11 @@ jobs:
   fmt:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          toolchain: nightly
-          components: rustfmt
-      - name: Run fmt check
-        run: cargo fmt --all -- --check
+      - uses: $/.github/actions/cargo-fmt
   clippy:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          toolchain: nightly
-          components: clippy
-      - name: Run clippy check
-        run: cargo clippy --all-targets --all-features
+      - uses: $/.github/actions/cargo-clippy
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,8 +35,6 @@ jobs:
           - nightly
         profile:
           - release
-    outputs:
-      release_built: ${{ steps.set-output.outputs.release_built }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Cache

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,8 +38,6 @@ jobs:
           - nightly
         profile:
           - release
-    outputs:
-      release_built: ${{ steps.set-output.outputs.release_built }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Cache

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,6 +59,29 @@ jobs:
           TARGET: ${{ matrix.target }}
       - name: Run tests in "${{ matrix.profile }}" mode
         run: cargo test --profile ${{ matrix.profile }}
+  build-static:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+          components: rust-src
+      - name: Install wasm-pack
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo install wasm-pack
+      - name: Build static site
+        run: wasm-pack build --target web --out-dir static/pkg
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,66 @@
+name: Push pipeline
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+
+jobs:
+  fmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: $/.github/actions/cargo-fmt
+  clippy:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: $/.github/actions/cargo-clippy
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-26
+          - macos-26-intel
+        toolchain:
+          - stable
+          - nightly
+        profile:
+          - release
+    outputs:
+      release_built: ${{ steps.set-output.outputs.release_built }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rust-src
+      - name: Build binaries in "${{ matrix.profile }}" mode
+        run: cargo build --profile ${{ matrix.profile }}
+        env:
+          TARGET: ${{ matrix.target }}
+      - name: Run tests in "${{ matrix.profile }}" mode
+        run: cargo test --profile ${{ matrix.profile }}
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: static
+          path: |
+            static

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 env:
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
## Summary

This adds a GitHub Actions workflow that builds the static site's WASM and JavaScript files whenever changes are pushed to the `main` branch.

Closes #32