### PR TITLE
Replace `console_error_panic_hook` with a `std::panic` hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,16 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,7 +42,6 @@ dependencies = [
 name = "gameboy"
 version = "0.3.0"
 dependencies = [
- "console_error_panic_hook",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/cli.rs"
 [dependencies]
 wasm-bindgen = "0.2.127"
 js-sys = "0.3.104"
-console_error_panic_hook = "0.1.7"
 
 [dependencies.web-sys]
 version = "0.3.104"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ use self::gb::cartridge::Cartridge;
 use self::gb::joypad::Button;
 use self::gb::screen::{SCREEN_H, SCREEN_W};
 use std::cell::RefCell;
+use std::panic;
 use std::rc::Rc;
+use wasm_bindgen::JsValue;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::{Clamped, JsCast};
@@ -21,7 +23,7 @@ macro_rules! enclose {
 
 #[wasm_bindgen(start)]
 pub fn main() -> Result<(), JsValue> {
-    console_error_panic_hook::set_once();
+    set_panic_hook();
 
     let gameboy = Rc::new(RefCell::new(GameBoy::new()));
     handle_custom_rom(gameboy.clone())?;
@@ -35,6 +37,12 @@ pub fn main() -> Result<(), JsValue> {
     async_render_loop(ctx, gameboy);
 
     Ok(())
+}
+
+fn set_panic_hook() {
+    panic::set_hook(Box::new(|info| {
+        web_sys::console::error_1(&JsValue::from_str(&info.to_string()));
+    }));
 }
 
 fn handle_custom_rom(gameboy: Rc<RefCell<GameBoy>>) -> Result<(), JsValue> {


### PR DESCRIPTION
# Summary

The `rustwasm` GitHub organization has been sunset, and the `console_error_panic_hook` crate is no longer maintained. The repository has also been archived since August 25, 2025.

This replaces the `console_error_panic_hook` crate with a `std::panic` hook.

Closes #43