### PR TITLE
Add an event listener to choose a ROM file using the `<select id="select-rom">` tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ version = "0.3.0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -128,6 +129,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,24 +14,27 @@ path = "src/cli.rs"
 
 [dependencies]
 wasm-bindgen = "0.2.127"
+wasm-bindgen-futures = "0.4.77"
 js-sys = "0.3.104"
 
 [dependencies.web-sys]
 version = "0.3.104"
 features = [
-  "console",
+  "CanvasRenderingContext2d",
   "Document",
   "Element",
-  "EventTarget",
   "Event",
-  "Window",
-  "HtmlCanvasElement",
-  "HtmlInputElement",
-  "CanvasRenderingContext2d",
-  "ImageData",
-  "KeyboardEvent",
+  "EventTarget",
   "File",
   "FileList",
   "FileReader",
+  "HtmlCanvasElement",
+  "HtmlInputElement",
+  "HtmlSelectElement",
+  "ImageData",
+  "KeyboardEvent",
   "ProgressEvent",
+  "Response",
+  "Window",
+  "console",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use self::gb::GameBoy;
 use self::gb::cartridge::Cartridge;
 use self::gb::joypad::Button;
 use self::gb::screen::{SCREEN_H, SCREEN_W};
+use js_sys::Uint8Array;
 use std::cell::RefCell;
 use std::panic;
 use std::rc::Rc;
@@ -11,8 +12,10 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::{Clamped, JsCast};
+use wasm_bindgen_futures::{JsFuture, spawn_local};
 use web_sys::{
-    CanvasRenderingContext2d, Event, HtmlCanvasElement, HtmlInputElement, ImageData, KeyboardEvent, ProgressEvent,
+    CanvasRenderingContext2d, Event, HtmlCanvasElement, HtmlInputElement, HtmlSelectElement, ImageData, KeyboardEvent,
+    ProgressEvent,
 };
 
 macro_rules! enclose {
@@ -26,8 +29,16 @@ pub fn main() -> Result<(), JsValue> {
     set_panic_hook();
 
     let gameboy = Rc::new(RefCell::new(GameBoy::new()));
-    handle_custom_rom(gameboy.clone())?;
+
     handle_input(gameboy.clone())?;
+    match handle_load_rom(gameboy.clone()) {
+        Ok(()) => (),
+        Err(msg) => web_sys::console::log_1(&msg),
+    };
+    match handle_select_rom(gameboy.clone()) {
+        Ok(()) => (),
+        Err(msg) => web_sys::console::log_1(&msg),
+    };
 
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
@@ -45,10 +56,12 @@ fn set_panic_hook() {
     }));
 }
 
-fn handle_custom_rom(gameboy: Rc<RefCell<GameBoy>>) -> Result<(), JsValue> {
+fn handle_load_rom(gameboy: Rc<RefCell<GameBoy>>) -> Result<(), JsValue> {
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
-    let load_rom_button = document.get_element_by_id("load-rom").unwrap();
+    let load_rom = document
+        .get_element_by_id("load-rom")
+        .ok_or_else(|| JsValue::from_str("element with 'load-rom' not found, skipping"))?;
 
     let closure = Closure::wrap(Box::new(move |event: Event| {
         let input: HtmlInputElement = event.target().unwrap().dyn_into().unwrap();
@@ -65,7 +78,7 @@ fn handle_custom_rom(gameboy: Rc<RefCell<GameBoy>>) -> Result<(), JsValue> {
 
         let onload = enclose!([gameboy, reader] Closure::wrap(Box::new(move |_: ProgressEvent| {
             let buffer = reader.result().unwrap();
-            let array = js_sys::Uint8Array::new(&buffer);
+            let array = Uint8Array::new(&buffer);
             let rom: Vec<u8> = array.to_vec();
 
             let cart = Cartridge::new(rom);
@@ -80,8 +93,57 @@ fn handle_custom_rom(gameboy: Rc<RefCell<GameBoy>>) -> Result<(), JsValue> {
         reader.read_as_array_buffer(&file).unwrap();
     }) as Box<dyn FnMut(Event)>);
 
-    load_rom_button.add_event_listener_with_callback("change", closure.as_ref().unchecked_ref())?;
+    load_rom.add_event_listener_with_callback("change", closure.as_ref().unchecked_ref())?;
     closure.forget();
+
+    Ok(())
+}
+
+fn handle_select_rom(gameboy: Rc<RefCell<GameBoy>>) -> Result<(), JsValue> {
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+    let select_rom = document
+        .get_element_by_id("select-rom")
+        .ok_or_else(|| JsValue::from_str("element with 'select-rom' not found, skipping"))?;
+
+    let closure = Closure::wrap(Box::new(move |event: Event| {
+        let select: HtmlSelectElement = event.target().unwrap().dyn_into().unwrap();
+        let path = select.value();
+
+        let window = window.clone();
+        let gameboy = gameboy.clone();
+
+        spawn_local(async move {
+            let result = async {
+                let response = JsFuture::from(window.fetch_with_str(&path)).await?;
+                let response: web_sys::Response = response.dyn_into()?;
+
+                if !response.ok() {
+                    return Err(JsValue::from_str("failed to load ROM"));
+                }
+
+                let buffer = JsFuture::from(response.array_buffer()?).await?;
+                let rom = Uint8Array::new(&buffer);
+
+                let cart = Cartridge::new(rom.to_vec());
+                gameboy.borrow_mut().pause();
+                gameboy.borrow_mut().load(cart);
+                gameboy.borrow_mut().unpause();
+                Ok::<(), JsValue>(())
+            }
+            .await;
+
+            if let Err(error) = result {
+                web_sys::console::error_1(&error);
+            }
+        });
+    }) as Box<dyn FnMut(Event)>);
+
+    select_rom.add_event_listener_with_callback("change", closure.as_ref().unchecked_ref())?;
+    closure.forget();
+
+    // Trigger the "change" to load the initial rom
+    select_rom.dispatch_event(&Event::new("change")?)?;
 
     Ok(())
 }

--- a/static/index.html
+++ b/static/index.html
@@ -1,4 +1,4 @@
-3<!doctype html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/static/index.html
+++ b/static/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+3<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -55,6 +55,10 @@
       <div class="cartridge">
         <span>
           Cartridge:
+          <select id="select-rom">
+            <option value="path/to/your/romfile">Your ROM</option>
+          </select>
+
           <input type="file" id="load-rom" />
         </span>
       </div>


### PR DESCRIPTION
# Summary

Currently, we need to prepare Game Boy ROM files and select them from local storage using the `<input type="file">` tag. This is not very convenient when we are continuously changing our source code during development.

This adds an event listener that allows choosing a ROM file using the `<select id="select-rom">` tag, so that we no longer need to select ROM files via the file dialog.